### PR TITLE
Gradient Computation for chains with vector inputs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleChains"
 uuid = "de6bee2f-e2f4-4ec7-b6ed-219cc6f6e9e5"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -409,7 +409,6 @@ function dense!(
 ) where {T1<:Base.HWReal,T2<:Base.HWReal,N}
   Kp1 = ArrayInterface.size(A, StaticInt(2))
   K = Kp1 - StaticInt(1)
-  n = StaticInt(1)
   @turbo for n ∈ indices((B, C), 2), m ∈ indices((A, C), 1)
     Cmn = zero(eltype(C))
     for k ∈ 1:K

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -422,10 +422,10 @@ function dense!(
 end
 function dense!(
   ::typeof(relu),
-  ∂C::AbstractArray{Bool,1},
-  C::AbstractArray{T1,1},
+  ∂C::AbstractVector{Bool},
+  C::AbstractVector{T1},
   A::AbstractMatrix,
-  B::AbstractArray{T2, 1},
+  B::AbstractVector{T2},
   ::True,
 ) where {T1<:Base.HWReal,T2<:Base.HWReal}
   Kp1 = ArrayInterface.size(A, StaticInt(2))

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -448,7 +448,7 @@ function dense!(
   @turbo for m ∈ indices((A, C), 1)
     Cmn = zero(eltype(C))
     for k ∈ 1:K
-      Cmn += A[m, k] * B[k, 1]
+      Cmn += A[m, k] * B[k, n]
     end
     Cmnr = Cmn + A[m, Kp1]
     Cmnr_gt_0 = Cmnr > zero(Cmnr)
@@ -483,10 +483,11 @@ function dense!(
   B::AbstractVector{T2},
   ::False,
 ) where {T1<:Base.HWReal,T2<:Base.HWReal}
+  K = ArrayInterface.size(A, StaticInt(2))
   n = StaticInt(1)
-  @turbo for m ∈ indices((A, C), 1) ###Error
+  @turbo for m ∈ indices((A, C), 1)
     Cmn = zero(eltype(C))
-    for k ∈ indices((A, B), 2, 1)
+    for k ∈ 1:K
       Cmn += A[m, k] * B[k, n]
     end
     Cmn_gt_0 = Cmn > zero(Cmn)

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -505,9 +505,7 @@ function dense!(
   ::False,
 ) where {T1<:Base.HWReal,T2<:Base.HWReal,N}
   @turbo for n ∈ indices((B, C), 2), m ∈ indices((A, C), 1)
-    Cmn = zero(eltype(C))
-    Cmn += A[m, 1] * B[1, n]
-    C[m, n] = Cmn
+    C[m, n] = A[m] * B[1, n]
   end
 end
 

--- a/test/layer_tests.jl
+++ b/test/layer_tests.jl
@@ -1,0 +1,54 @@
+using SimpleChains, Zygote, Test
+
+x = rand(5)
+y = rand(2)
+
+sc = SimpleChain(
+  static(5),
+  TurboDense{true}(tanh, 5),
+  TurboDense{false}(tanh, 5),
+  TurboDense{true}(SimpleChains.relu, 5),
+  SimpleChains.Dropout(0.3),
+  TurboDense{false}(SimpleChains.relu, 5),
+  TurboDense{true}(identity, 2),
+  TurboDense{false}(identity, 2),
+  SquaredLoss(y)
+)
+
+p = SimpleChains.init_params(sc)
+gz = Zygote.gradient(sc, x, p)[2]
+
+g = similar(p)
+valgrad!(g, sc, x, p)
+
+@test size(gz) == size(p)
+@test size(g) == size(gz)
+
+@test !iszero(gz)
+@test !iszero(g)
+
+xmat = rand(5, 20)
+ymat = rand(2, 20)
+
+sc2 = SimpleChain(
+    static(5),
+    TurboDense{true}(tanh, 5),
+    TurboDense{false}(tanh, 5),
+    TurboDense{true}(SimpleChains.relu, 5),
+    SimpleChains.Dropout(0.3),
+    TurboDense{false}(SimpleChains.relu, 5),
+    TurboDense{true}(identity, 2),
+    TurboDense{false}(identity, 2),
+    SquaredLoss(ymat)
+)
+
+p2 = SimpleChains.init_params(sc2)
+gz2 = Zygote.gradient(sc, xmat, p2)[2]
+g2 = similar(p2)
+valgrad!(g2, sc, xmat, p2)
+
+@test size(gz2) == size(p2)
+@test size(g2) == size(gz2)
+
+@test !iszero(gz2)
+@test !iszero(g2)

--- a/test/layer_tests.jl
+++ b/test/layer_tests.jl
@@ -18,8 +18,10 @@ sc = SimpleChain(
 p = SimpleChains.init_params(sc)
 
 g = similar(p)
+SimpleChains.VectorizedRNG.seed!(1);
 valgrad!(g, sc, x, p)
 
+SimpleChains.VectorizedRNG.seed!(1);
 gz = Zygote.gradient(sc, x, p)[2]
 
 @test size(gz) == size(p)
@@ -33,23 +35,15 @@ gz = Zygote.gradient(sc, x, p)[2]
 xmat = rand(5, 20)
 ymat = rand(2, 20)
 
-sc2 = SimpleChain(
-    static(5),
-    TurboDense{true}(tanh, 5),
-    TurboDense{false}(tanh, 5),
-    TurboDense{true}(SimpleChains.relu, 5),
-    SimpleChains.Dropout(0.3),
-    TurboDense{false}(SimpleChains.relu, 5),
-    TurboDense{true}(identity, 2),
-    TurboDense{false}(identity, 2),
-    SquaredLoss(ymat)
-)
+sc2 = SimpleChains.add_loss(sc, SquaredLoss(ymat))
 
 p2 = SimpleChains.init_params(sc2)
 
 g2 = similar(p2)
+SimpleChains.VectorizedRNG.seed!(2);
 valgrad!(g2, sc2, xmat, p2)
 
+SimpleChains.VectorizedRNG.seed!(2);
 gz2 = Zygote.gradient(sc2, xmat, p2)[2]
 
 @test size(gz2) == size(p2)

--- a/test/layer_tests.jl
+++ b/test/layer_tests.jl
@@ -16,16 +16,19 @@ sc = SimpleChain(
 )
 
 p = SimpleChains.init_params(sc)
-gz = Zygote.gradient(sc, x, p)[2]
 
 g = similar(p)
 valgrad!(g, sc, x, p)
+
+gz = Zygote.gradient(sc, x, p)[2]
 
 @test size(gz) == size(p)
 @test size(g) == size(gz)
 
 @test !iszero(gz)
 @test !iszero(g)
+
+@test gz ≈ g rtol=1e-6
 
 xmat = rand(5, 20)
 ymat = rand(2, 20)
@@ -43,12 +46,16 @@ sc2 = SimpleChain(
 )
 
 p2 = SimpleChains.init_params(sc2)
-gz2 = Zygote.gradient(sc, xmat, p2)[2]
+
 g2 = similar(p2)
-valgrad!(g2, sc, xmat, p2)
+valgrad!(g2, sc2, xmat, p2)
+
+gz2 = Zygote.gradient(sc2, xmat, p2)[2]
 
 @test size(gz2) == size(p2)
 @test size(g2) == size(gz2)
 
 @test !iszero(gz2)
 @test !iszero(g2)
+
+@test g2 ≈ gz2 rtol=1e-6

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -470,6 +470,9 @@ dual(x::ForwardDiff.Dual) = ForwardDiff.Dual(x, dual(randn()), dual(randn()))
   @testset "LeNet" begin
     include("mnist.jl")
   end
+  @testset "Layer Tests" begin
+    include("layer_tests.jl")
+  end
   @testset "params" begin
     sc = SimpleChain(
       static(24),
@@ -486,36 +489,6 @@ dual(x::ForwardDiff.Dual) = ForwardDiff.Dual(x, dual(randn()), dual(randn()))
     @test W1 == reshape(view(p,1:24*8),(8,24))
     @test b1 == view(p,24*8+1:25*8)
     @test W3 == reshape(@view(p[25*8+1:end]),(2,8))
-  end
-  @testset "vector inputs" begin
-    x = rand(5)
-    y = rand(2)
-
-    sc = SimpleChain(
-      static(5),
-      TurboDense{true}(tanh, 5),
-      TurboDense{false}(tanh, 5),
-      TurboDense{true}(SimpleChains.relu, 5),
-      SimpleChains.Dropout(0.3),
-      TurboDense{false}(SimpleChains.relu, 5),
-      TurboDense{true}(identity, 2),
-      TurboDense{false}(identity, 2),
-      SquaredLoss(y)
-    )
-
-    p = SimpleChains.init_params(sc)
-    gz = Zygote.gradient(sc, x, p)[2]
-
-    g = similar(p)
-    valgrad!(g, sc, x, p)
-
-    @test size(gz) == size(p)
-    @test size(g) == size(gz)
-
-    @test !iszero(gz)
-    @test !iszero(g)
-
-    @test g ≈ gz rtol=1e-6
   end
 end
 # TODO: test ambiguities once ForwardDiff fixes them, or once ForwardDiff is dropped

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -516,6 +516,7 @@ dual(x::ForwardDiff.Dual) = ForwardDiff.Dual(x, dual(randn()), dual(randn()))
     @test !iszero(g)
 
     @test g ≈ gz rtol=1e-6
+  end
 end
 # TODO: test ambiguities once ForwardDiff fixes them, or once ForwardDiff is dropped
 # For now, there are the tests at the start.


### PR DESCRIPTION
Added dispatches of `dense!` for gradient computation for chains having vector input with `tanh` and `relu` activations. Resolves #54 