### PR TITLE
thread safety through using task-local storage on non-inplace

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleChains"
 uuid = "de6bee2f-e2f4-4ec7-b6ed-219cc6f6e9e5"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
-version = "0.2.10"
+version = "0.2.11"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/simple_chain.jl
+++ b/src/simple_chain.jl
@@ -182,9 +182,18 @@ function verify_arg(c, arg)
     throw(ArgumentError("Input argument: !matches(chain_input_dims(c), size(arg))"))
   end
 end
-function (c::SimpleChain)(arg, params)
+
+function task_local_memory()::Vector{UInt8}
+  get!(
+    task_local_storage(),
+    Symbol("#SIMPLE#CHAINS#TASK#LOCAL#STORAGE#"),
+    UInt8[]
+  )::Vector{UInt8}
+end
+
+function (c::SimpleChain)(arg, params, memory = task_local_memory())
   verify_arg(c, arg)
-  @unpack layers, memory = c
+  @unpack layers = c
   parg = maybe_static_size_arg(c.inputdim, arg)
   resize_memory!(layers, memory, parg)
   GC.@preserve arg unsafe_chain(layers, params, memory, parg)
@@ -298,9 +307,9 @@ Accepts adjoint of its return (`C̄`). It is allowed to destroy this.
 It is also allowed to destroy the previous layer's return `B` to produce `B̄` (the `C̄` it receives).
 Thus, the pullback is not allowed to depend on `C`, as it may have been destroyed in producing `C̄`.
 """
-function valgrad!(g, c::SimpleChain, arg, params)
+function valgrad!(g, c::SimpleChain, arg, params, memory = c.memory)
   verify_arg(c, arg)
-  @unpack layers, memory = c
+  @unpack layers = c
   parg = maybe_static_size_arg(c.inputdim, arg)
   resize_memory!(layers, memory, parg)
   GC.@preserve arg begin
@@ -387,9 +396,12 @@ function chain_valgrad!(pg, arg, layers::Tuple{X}, p::Ptr, pu::Ptr{UInt8}) where
   return val, lgrad, pu3
 end
 @inline getchain(sc::SimpleChain) = sc
-function valgrad(sc, arg, params::AbstractVector{T}) where {T}
+function valgrad(
+  sc, arg, params::AbstractVector{T},
+  memory = task_local_memory()
+) where {T}
   c = getchain(sc)
-  @unpack layers, memory = c
+  @unpack layers = c
   parg = maybe_static_size_arg(c.inputdim, arg)
   off = align(resize_memory!(layers, memory, parg))
   GC.@preserve memory arg begin

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -7,4 +7,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
-MLDatasets = "0.6"
+MLDatasets = "0.6, 0.7"


### PR DESCRIPTION
functions; `(sc::SimpleChain)(args...)` and `valgrad(...)` w/out bang

Users should avoid using task_local_storage, especially in short lived tasks. If you must use it, try and have long-lived tasks, and communicate with them using channels.

But, probably worth defaulting to correctness for the sake of end users.

These are also the methods that are going to be hit in `ForwardDiff` and `Zygote` code that is likely to be multithreaded.