### PR TITLE
Broadcasted bias should not broadcast against duals.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleChains"
 uuid = "de6bee2f-e2f4-4ec7-b6ed-219cc6f6e9e5"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
-version = "0.2.9"
+version = "0.2.10"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/test/matmul_tests.jl
+++ b/test/matmul_tests.jl
@@ -16,9 +16,9 @@ for bias in (true, false)
   M = 16
   K = 20
   N = 17
-  A = rand(M, K + bias)
-  B = rand(K, N)
-  bm = rand(K, 1)
+  A = rand(M, K + bias);
+  B = rand(K, N);
+  bm = rand(K, 1);
 
   for fa1 in (identity, dual4x3),
     fa2 in (identity, dual4x3),
@@ -44,15 +44,15 @@ for bias in (true, false)
       end
       
       SimpleChains.matmul!(C, A, B, static(bias))
-      @test C ≈ AB
+      @test reinterpret(Float64,C) ≈ reinterpret(Float64,AB)
       SimpleChains.matmul!(c, A, b, static(bias))
-      @test c ≈ Ab
+      @test reinterpret(Float64,c) ≈ reinterpret(Float64,Ab)
       SimpleChains.matmul!(c, A, bm, static(bias))
-      @test c ≈ Ab
+      @test reinterpret(Float64,c) ≈ reinterpret(Float64,Ab)
       SimpleChains.matmul!(cm, A, b, static(bias))
-      @test vec(cm) ≈ Ab
+      @test reinterpret(Float64,vec(cm)) ≈ reinterpret(Float64,Ab)
       SimpleChains.matmul!(cm, A, bm, static(bias))
-      @test vec(cm) ≈ Ab
+      @test reinterpret(Float64,vec(cm)) ≈ reinterpret(Float64,Ab)
     end
   end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,8 +4,10 @@ using Test, Aqua, ForwardDiff, Zygote
 function countallocations!(g, sc, x, p)
   @allocated valgrad!(g, sc, x, p)
 end
-dual(x) = ForwardDiff.Dual(x, randn(), randn(), randn())
-dual(x::ForwardDiff.Dual) = ForwardDiff.Dual(x, dual(randn()), dual(randn()))
+dual(x::T) where {T} = ForwardDiff.Dual(x, 4randn(T), 4randn(T), 4randn(T))
+function dual(x::ForwardDiff.Dual{<:Any,T}) where {T}
+  ForwardDiff.Dual(x, dual(4randn(T)), dual(4randn(T)))
+end
 
 import InteractiveUtils
 InteractiveUtils.versioninfo(verbose=true)
@@ -252,65 +254,37 @@ InteractiveUtils.versioninfo(verbose=true)
         undef,
         first(SimpleChains.layer_output_size(Val(eltype(xdd)), td, size(x))),
       )
-
-      A = reshape(view(p, 1:8*24), (8, 24))
-      b = view(p, 1+8*24:8*25)
-      Ad = reshape(view(pd, 1:8*24), (8, 24))
-      bd = view(pd, 1+8*24:8*25)
+      dim = size(x,1);
+      A = reshape(view(p, 1:8dim), (8, dim))
+      b = view(p, 1+8dim:8*25)
+      Ad = reshape(view(pd, 1:8dim), (8, dim))
+      bd = view(pd, 1+8dim:8*25)
       ld = tanh.(Ad * x .+ bd)
       l_d = tanh.(A * xd .+ b)
       ld_d = tanh.(Ad * xd .+ bd)
 
-      Add = reshape(view(pdd, 1:8*24), (8, 24))
-      bdd = view(pdd, 1+8*24:8*25)
+      Add = reshape(view(pdd, 1:8dim), (8, dim))
+      bdd = view(pdd, 1+8dim:8*25)
       ldd = tanh.(Add * x .+ bdd)
       ldd_dd = tanh.(Add * xdd .+ bdd)
-      if T === Float64
-        GC.@preserve pd pu begin
-          @test reinterpret(T, ld) ≈ reinterpret(T, td(x, pointer(pd), pointer(pu))[1])
-          @test reinterpret(T, ld) ≈
-                reinterpret(T, td(permutedims(x)', pointer(pd), pointer(pu))[1])
-          @test reinterpret(T, l_d) ≈ reinterpret(T, td(xd, pointer(p), pointer(pu))[1])
-          @test reinterpret(T, l_d) ≈
-                reinterpret(T, td(permutedims(xd)', pointer(p), pointer(pu))[1])
-          @test reinterpret(T, ld_d) ≈ reinterpret(T, td(xd, pointer(pd), pointer(pu))[1])
-          @test reinterpret(T, ld_d) ≈
-                reinterpret(T, td(permutedims(xd)', pointer(pd), pointer(pu))[1])
+      GC.@preserve pd pu begin
+        @test reinterpret(T, ld) ≈ reinterpret(T, td(x, pointer(pd), pointer(pu))[1])
+        @test reinterpret(T, ld) ≈
+          reinterpret(T, td(permutedims(x)', pointer(pd), pointer(pu))[1])
+        @test reinterpret(T, l_d) ≈ reinterpret(T, td(xd, pointer(p), pointer(pu))[1])
+        @test reinterpret(T, l_d) ≈
+          reinterpret(T, td(permutedims(xd)', pointer(p), pointer(pu))[1])
+        @test reinterpret(T, ld_d) ≈ reinterpret(T, td(xd, pointer(pd), pointer(pu))[1])
+        @test reinterpret(T, ld_d) ≈
+          reinterpret(T, td(permutedims(xd)', pointer(pd), pointer(pu))[1])
 
-          @test reinterpret(T, ldd) ≈ reinterpret(T, td(x, pointer(pdd), pointer(pu))[1])
-          @test reinterpret(T, ldd_dd) ≈
-                reinterpret(T, td(xdd, pointer(pdd), pointer(pu))[1])
-          @test reinterpret(T, ldd) ≈
-                reinterpret(T, td(permutedims(x)', pointer(pdd), pointer(pu))[1])
-          @test reinterpret(T, ldd_dd) ≈
-                reinterpret(T, td(permutedims(xdd)', pointer(pdd), pointer(pu))[1])
-        end
-      else
-        GC.@preserve pd pu begin
-          @test_broken reinterpret(T, ld) ≈
-                       reinterpret(T, td(x, pointer(pd), pointer(pu))[1])
-          @test_broken reinterpret(T, l_d) ≈
-                       reinterpret(T, td(xd, pointer(p), pointer(pu))[1])
-          @test_broken reinterpret(T, ld_d) ≈
-                       reinterpret(T, td(xd, pointer(pd), pointer(pu))[1])
-
-          @test_broken reinterpret(T, ldd) ≈
-                       reinterpret(T, td(x, pointer(pdd), pointer(pu))[1])
-          @test_broken reinterpret(T, ldd_dd) ≈
-            reinterpret(T, td(xdd, pointer(pdd), pointer(pu))[1])
-
-          @test_broken reinterpret(T, ld) ≈
-                       reinterpret(T, td(permutedims(x)', pointer(pd), pointer(pu))[1])
-          @test_broken reinterpret(T, l_d) ≈
-                       reinterpret(T, td(permutedims(xd)', pointer(p), pointer(pu))[1])
-          @test_broken reinterpret(T, ld_d) ≈
-                       reinterpret(T, td(permutedims(xd)', pointer(pd), pointer(pu))[1])
-
-          @test_broken reinterpret(T, ldd) ≈
-                       reinterpret(T, td(permutedims(x)', pointer(pdd), pointer(pu))[1])
-          @test_broken reinterpret(T, ldd_dd) ≈
-                       reinterpret(T, td(permutedims(xdd)', pointer(pdd), pointer(pu))[1])
-        end
+        @test reinterpret(T, ldd) ≈ reinterpret(T, td(x, pointer(pdd), pointer(pu))[1])
+        @test reinterpret(T, ldd_dd) ≈
+          reinterpret(T, td(xdd, pointer(pdd), pointer(pu))[1])
+        @test reinterpret(T, ldd) ≈
+          reinterpret(T, td(permutedims(x)', pointer(pdd), pointer(pu))[1])
+        @test reinterpret(T, ldd_dd) ≈
+          reinterpret(T, td(permutedims(xdd)', pointer(pdd), pointer(pu))[1])
       end
       @testset "training" begin
         p .= randn.() .* 100


### PR DESCRIPTION
I accidentally didn't realize the `matmul!` tests weren't very useful
```julia
julia> [ForwardDiff.Dual(1.4,NaN,2.34,Inf)] ≈ [ForwardDiff.Dual(1.4,9001.0,-1e4,-Inf)]
true

julia> reinterpret(Float64,[ForwardDiff.Dual(1.4,NaN,2.34,Inf)]) ≈ reinterpret(Float64,[ForwardDiff.Dual(1.4,9001.0,-1e4,-Inf)])
false
```
And there were a few `@test_broken` that I should have looked into sooner.