### PR TITLE
10x faster task_local_memory

### DIFF
--- a/src/simple_chain.jl
+++ b/src/simple_chain.jl
@@ -163,12 +163,12 @@ function verify_arg(c, arg)
 end
 
 function task_local_memory()::Vector{UInt8}
-  get!(
+  (get!(
     task_local_storage(),
     Symbol("#SIMPLE#CHAINS#TASK#LOCAL#STORAGE#")
   ) do
     UInt8[]
-  end
+  end)::Vector{UInt8}
 end
 
 function (c::SimpleChain)(arg, params, memory = task_local_memory())


### PR DESCRIPTION
This is better than it was before, but I'll follow up with another PR to use stack-allocated memory in many cases. That'll probably have to wait until Monday.

As for this PR, the old version was slow because adding type asserts on a function means to call `convert` and then to type-assert, while adding it on a function return only means to type assert.

Getting from an `IdDict{Any,Any}` of course infers as `Any`, which then means we need a dynamic dispatch to the `convert`. By only having the type assert, we instead get a fast check to confirm the type and then an error.
I left the type assert on the function as well, but as the type has now already been confirmed by the time the function returns, we have a static dispatch to convert (that gets compiled away, because it's already known to be the correct type).