### PR TITLE
promote types for calculating num_bytes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleChains"
 uuid = "de6bee2f-e2f4-4ec7-b6ed-219cc6f6e9e5"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/SimpleChains.jl
+++ b/src/SimpleChains.jl
@@ -68,6 +68,7 @@ export SimpleChain,
   FrontLastPenalty
 
 const Integer = Union{StaticInt,Base.Integer}
+const MAXSTACK = 16384
 
 include("memory.jl")
 include("simple_chain.jl")

--- a/src/chain_rules.jl
+++ b/src/chain_rules.jl
@@ -123,7 +123,7 @@ function valgrad_noloss(sc, arg::AbstractArray{S}, params::AbstractVector{T}) wh
   goff = align(glen * static_sizeof(T))
   aoff = align(arglen * static_sizeof(S))
 
-  num_bytes = required_bytes(Val{T}(), layers, size(parg), aoff + goff)
+  num_bytes = required_bytes(Val{promote_type(T,S)}(), layers, size(parg), aoff + goff)
   memory = get_heap_memory(sc, num_bytes)
 
   GC.@preserve barg params memory begin

--- a/test/mnist.jl
+++ b/test/mnist.jl
@@ -14,9 +14,9 @@ lenet = SimpleChain(
   TurboDense(SimpleChains.relu, 84),
   TurboDense(identity, 10),
 )
-# 3d and 0-indexed
-xtrain3, ytrain0 = MLDatasets.MNIST.traindata(Float32);
-xtest3, ytest0 = MLDatasets.MNIST.testdata(Float32);
+  # 3d and 0-indexed
+xtrain3, ytrain0 = MLDatasets.MNIST(:train)[:]
+xtest3, ytest0 = MLDatasets.MNIST(:test)[:]
 xtrain4 = reshape(xtrain3, 28, 28, 1, :);
 xtest4 = reshape(xtest3, 28, 28, 1, :);
 ytrain1 = UInt32.(ytrain0 .+ 1);

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -268,6 +268,7 @@ InteractiveUtils.versioninfo(verbose=true)
       ldd = tanh.(Add * x .+ bdd)
       ldd_dd = tanh.(Add * xdd .+ bdd)
       GC.@preserve pd pu begin
+        @test reinterpret(T, td(x, pointer(pd), pointer(pu))[1]) == reinterpret(T, SimpleChain(td)(x, pd))
         @test reinterpret(T, ld) ≈ reinterpret(T, td(x, pointer(pd), pointer(pu))[1])
         @test reinterpret(T, ld) ≈
           reinterpret(T, td(permutedims(x)', pointer(pd), pointer(pu))[1])


### PR DESCRIPTION
On the latest release, I get this for the added test:
```julia
julia> @test reinterpret(T, td(x, pointer(pd), pointer(pu))[1]) == reinterpret(T, SimpleChain(td)(x, pd))
free(): corrupted unsorted chunks

signal (6): Aborted
in expression starting at REPL[71]:1
```