### PR TITLE
Fix custom loss layer documentation

### DIFF
--- a/docs/src/examples/custom_loss_layer.md
+++ b/docs/src/examples/custom_loss_layer.md
@@ -1,6 +1,6 @@
 # Adding a custom loss layer
 
-Loss functions like the `LogitCrossEntropyLoss` are defined for users to be able to quickly prototype models on new problems. However, sometimes there is a need to write one's own customised loss function. This example will walk through this process.
+Loss functions like the `LogitCrossEntropyLoss` are defined for users to be able to quickly prototype models on new problems. However, sometimes there is a need to write one's own customized loss function. This example will walk through this process.
 
 To show which functions need to be implemented for your own custom loss, this example will walk through implementing a `BinaryLogitCrossEntropyLoss`, which acts on a model with only a single output, and binary targets.
 
@@ -10,7 +10,7 @@ Consider the following model:
 ```math
 p_\theta(X_i) = \sigma (f(X_i)),
 ```
-where ``X_i`` is the input features, ``\sigma`` is the sigmoid function, given by ``\sigma(x)=(1+e^{-x})^{-1}`` and ``f_\theta`` is some function mapping defined by your model, which is parameterised by parameters ``\theta``. The output of ``f_\theta (X_i)`` is called the "logit". The loss function we want to calculate is the following:
+where ``X_i`` is the input features, ``\sigma`` is the sigmoid function, given by ``\sigma(x)=(1+e^{-x})^{-1}`` and ``f_\theta`` is some function mapping defined by your model, which is parameterized by parameters ``\theta``. The output of ``f_\theta (X_i)`` is called the "logit". The loss function we want to calculate is the following:
 
 ```math
 L(\theta| X, Y) = -\sum_i \left [ Y_i\ln{p_\theta (X_i)} + (1-Y_i)\ln{(1-p_\theta (X_i))} \right ],

--- a/docs/src/examples/custom_loss_layer.md
+++ b/docs/src/examples/custom_loss_layer.md
@@ -27,7 +27,7 @@ To simplify this calculation, we can use the fact that ``1-p_\theta (x)=p_\theta
 \frac{{\partial }}{{\partial } \theta} L(\theta| X, Y) = -\sum_i \left [ (2Y_i - 1){\left (1+e^{(2Y_i-1)f_\theta(X_i)} \right )}^{-1} \right ] \frac{{\partial }}{{\partial } \theta} f_\theta(X_i).
 ```
 
-We have managed to write the derivative of the loss function, in terms of the derivative of the model, independently for each sample. The important part of this equation is the multiplicand of the partial derivative term; this term is the partial gradient used for backpropagation. From this point, we can begin writing the code.
+We have managed to write the derivative of the loss function, in terms of the derivative of the model, independently for each sample. The important part of this equation is the multiplicand of the partial derivative term; this term is the partial gradient used for back-propagation. From this point, we can begin writing the code.
 
 ## Implementing a custom loss type
 
@@ -44,12 +44,18 @@ struct BinaryLogitCrossEntropyLoss{T,Y<:AbstractVector{T}} <: SimpleChains.Abstr
 end
 ```
 
+The function used to get the inner targets is called `target` and can be defined easily:
+```julia
+target(loss::BinaryLogitCrossEntropyLoss) = loss.targets
+(loss::BinaryLogitCrossEntropyLoss)(::Int) = loss
+```
+
 Next, we define how to calculate the loss, given some logits:
 
 ```julia
 function calculate_loss(loss::BinaryLogitCrossEntropyLoss, logits)
     y = loss.targets
-    total_loss = zero(T)
+    total_loss = zero(eltype(logits))
     for i in eachindex(y)
         p_i = inv(1 + exp(-logits[i]))
         y_i = y[i]
@@ -57,7 +63,7 @@ function calculate_loss(loss::BinaryLogitCrossEntropyLoss, logits)
     end
     total_loss
 end
-function (loss::BinaryLogitCrossEntropyLoss)(previous_layer_output::AbstractArray{T}, p::Ptr, pu)
+function (loss::BinaryLogitCrossEntropyLoss)(previous_layer_output::AbstractArray{T}, p::Ptr, pu) where {T}
     total_loss = calculate_loss(loss, previous_layer_output)
     total_loss, p, pu
 end
@@ -73,7 +79,7 @@ function SimpleChains.forward_layer_output_size(::Val{T}, sl::BinaryLogitCrossEn
 end
 ```
 
-Finally, we define how to backpropagate the gradient from this loss function:
+Finally, we define how to back-propagate the gradient from this loss function:
 
 ```julia
 function SimpleChains.chain_valgrad!(
@@ -116,11 +122,17 @@ X = rand(Float32, 2, batch_size)
 Y = rand(Bool, batch_size)
 
 parameters = SimpleChains.init_params(model);
-gradients = G = SimpleChains.alloc_threaded_grad(model);
+gradients = SimpleChains.alloc_threaded_grad(model);
 
 # Add the loss like any other loss type
 model_loss = SimpleChains.add_loss(model, BinaryLogitCrossEntropyLoss(Y));
 
 
 SimpleChains.valgrad!(gradients, model_loss, X, parameters)
+```
+
+Or alternatively, if you want to just train the parameters in full:
+```julia
+epochs = 100
+SimpleChains.train_unbatched!(gradients, parameters, model_loss, X, SimpleChains.ADAM(), 1:epochs); 
 ```


### PR DESCRIPTION
As brought up in [this thread](https://discourse.julialang.org/t/simplechains-method-error-with-custom-loss-function-and-train-unbatched/89828), the example from the docs was incomplete, missing methods for the `target` function and one for selecting the loss for a given epoch (that is my understanding anyway). This was added, along with some spelling and grammar changes as well.