### PR TITLE
Use `Threads.nthreads`, not `CPUSummary.num_threads`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -29,7 +29,7 @@ VectorizedRNG = "33b4df10-0173-11e9-2a0c-851a7edac40e"
 [compat]
 ArrayInterface = "6"
 ArrayInterfaceCore = "0.1.14"
-CPUSummary = "0.1.8"
+CPUSummary = "0.1.8, 0.2"
 ChainRulesCore = "0.8, 0.9, 0.10, 1"
 CloseOpenIntervals = "0.1.6"
 ForwardDiff = "0.10"

--- a/src/SimpleChains.jl
+++ b/src/SimpleChains.jl
@@ -30,7 +30,7 @@ using SIMDTypes: Bit, NativeTypes
 using VectorizationBase: align, relu, stridedpointer, AbstractSIMD, NativeTypesV
 using HostCPUFeatures:
   static_sizeof, register_size, register_count, static_sizeof
-using CPUSummary: cache_linesize, num_threads, num_cores
+using CPUSummary: cache_linesize, num_cores
 using LayoutPointers:
   bytestrideindex, stridedpointer, zstridedpointer, zero_offsets, val_dense_dims
 using Static: One, lt

--- a/src/penalty.jl
+++ b/src/penalty.jl
@@ -27,7 +27,7 @@ alloc_threaded_grad(
   c::AbstractPenalty,
   id::Union{Nothing,InputDim} = nothing,
   ::Type{T} = Float32;
-  numthreads = _min(num_threads(), num_cores())
+  numthreads = _numthreads()
 ) where {T} = alloc_threaded_grad(getchain(c), id, T; numthreads)
 
 UnPack.unpack(c::AbstractPenalty{<:SimpleChain}, ::Val{:layers}) =

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -19,12 +19,12 @@ tssum(x) = ArrayInterface.reduce_tup(+, x)
 tssum(::Tuple{}) = static(0)
 
 maximum_turbo!(m, y) = @turbo for i in indices((m, y), (1, 2))
-    mi = typemin(eltype(y))
-    for j in axes(y, 1)
-      mi = max(mi, y[j, i])
-    end
-    m[i] = mi
+  mi = typemin(eltype(y))
+  for j in axes(y, 1)
+    mi = max(mi, y[j, i])
   end
+  m[i] = mi
+end
 
 function unnormalized_logsoftmax!(z, m, y::AbstractMatrix)
   maximum_turbo!(m, y)
@@ -220,8 +220,8 @@ function _alloc_grad(mem::Vector{T}, np, numthreads, x) where {T}
   StrideArray(_alloc_grad(align(pointer(mem)), np, numthreads, x), mem)
 end
 
-_min(a, b) = ifelse(lt(a, b), a, b)
-_numthreads() = _min(num_threads(), num_cores())
+_numthreads() = min(Threads.nthreads(), convert(Int, num_cores())::Int)::Int
+
 """
     alloc_threaded_grad(chn, id = nothing, ::Type{T} = Float32; numthreads = min(Threads.nthreads(), SimpleChains.num_cores())
 


### PR DESCRIPTION
`num_threads` is deprecated.
I believe `nthreads` will also be deprecated eventually (its meaning is less clear when you have throughput + ui threads), but for now it is less problematic.