### PR TITLE
Use `muladd` explicitly inside `contract`.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleChains"
 uuid = "de6bee2f-e2f4-4ec7-b6ed-219cc6f6e9e5"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
-version = "0.4.3"
+version = "0.4.4"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/SimpleChains.jl
+++ b/src/SimpleChains.jl
@@ -100,7 +100,8 @@ if VERSION >= v"1.7.0" && hasfield(Method, :recursion_relation)
     output_size,
     forward_output_size,
     _numparam,
-    pullback_layer!
+    pullback_layer!,
+    contract!
   )
     for m in methods(f)
       m.recursion_relation = dont_limit

--- a/src/forwarddiff_matmul.jl
+++ b/src/forwarddiff_matmul.jl
@@ -170,7 +170,7 @@ function contract_loops(
     end
     push!(Bref.args, dimsym)
   end
-  q = :(Caccum += $Aref * $Bref)
+  q = :(Caccum = muladd($Aref, $Bref, Caccum))
   for (i, d) in enumerate(contract_dims)
     da = findfirst(==(d), DA)
     db = findfirst(==(d), DB)


### PR DESCRIPTION
This avoids a need to call `mulexpr`. The `@turbo` preprocessing replaces `a + b*c` (and similar expressions, like `a += b*c`) with `muladd`, in order to simplify some downstream code (i.e. cost modelling). However, due to what is probably a Julia deserialization bug on Julia 1.8.5, this can cause problems when building sysimages. Thus, we avoid the need for doing it manually here via just calling `muladd` in the first place, rather than requiring the substitution to happen later.
Plus, not requiring it should be faster by an extremely minor amount.